### PR TITLE
Add preprocessors for AZIK

### DIFF
--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1303,12 +1303,7 @@ function! s:asym_prefilter(stash) abort "{{{
         " 'L' is mode:{hira,kata,hankata}:to-zenei
         return [char]
     elseif char ==# 'Q' && g:eskk#use_azik
-        let buf_str = a:stash.preedit.get_current_buf_str()
-        if !buf_str.rom_str.empty() && buf_str.rom_pairs.empty()
-            return [tolower(char)]
-        else
-            return [sticky_char, "nn"]
-        endif
+        return [sticky_char, "nn"]
     elseif char =~# '^[A-Z]$'
         " Treat uppercase "A" in "SAkujo" as lowercase.
         "
@@ -1326,7 +1321,7 @@ function! s:asym_prefilter(stash) abort "{{{
         endif
     elseif char ==# "+" && g:eskk#use_azik && g:eskk#azik_keyboard_type == 'jp106'
       \ || char ==# ":" && g:eskk#use_azik && g:eskk#azik_keyboard_type == 'us101'
-        return [sticky_char, "ta", ";"]
+        return [sticky_char, "t;"]
     elseif char ==# "\<BS>"
         return ["\<C-h>"]
     else

--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1497,6 +1497,10 @@ function! eskk#_initialize() abort "{{{
 
     call eskk#util#set_default('g:eskk#fix_extra_okuri', 1)
     call eskk#util#set_default('g:eskk#convert_at_exact_match', 0)
+
+    " AZIK
+    call eskk#util#set_default('g:eskk#use_azik', 0)
+    call eskk#util#set_default('g:eskk#azik_keyboard_type', 'jp106')
     " }}}
 
     " Throw "eskk-initialize-pre" autocmd event. {{{

--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1306,30 +1306,30 @@ function! s:asym_prefilter(stash) abort "{{{
         let buf_str = a:stash.preedit.get_current_buf_str()
         if !buf_str.rom_str.empty() && buf_str.rom_pairs.empty()
             if char ==# 'Z'
-                return ["a", sticky_char, "nn"]
+                return ['a', sticky_char, 'nn']
             elseif char ==# 'K'
-                return ["i", sticky_char, "nn"]
+                return ['i', sticky_char, 'nn']
             elseif char ==# 'J'
-                return ["u", sticky_char, "nn"]
+                return ['u', sticky_char, 'nn']
             elseif char ==# 'D'
-                return ["e", sticky_char, "nn"]
+                return ['e', sticky_char, 'nn']
             elseif char ==# 'L'
-                return ["o", sticky_char, "nn"]
+                return ['o', sticky_char, 'nn']
             elseif char ==# 'Q'
-                return ["a", sticky_char, "i"]
+                return ['a', sticky_char, 'i']
             elseif char ==# 'H'
-                return ["u", sticky_char, "u"]
+                return ['u', sticky_char, 'u']
             elseif char ==# 'W'
-                return ["e", sticky_char, "i"]
+                return ['e', sticky_char, 'i']
             elseif char ==# 'P'
-                return ["o", sticky_char, "u"]
+                return ['o', sticky_char, 'u']
             endif
         else
             if char ==# 'L'
                 " 'L' is mode:{hira,kata,hankata}:to-zenei
                 return [char]
             elseif char ==# 'Q'
-                return [sticky_char, "nn"]
+                return [sticky_char, 'nn']
             else
                 return [sticky_char, tolower(char)]
             endif
@@ -1349,9 +1349,9 @@ function! s:asym_prefilter(stash) abort "{{{
         else
             return [sticky_char, tolower(char)]
         endif
-    elseif char ==# "+" && g:eskk#use_azik && g:eskk#azik_keyboard_type == 'jp106'
-      \ || char ==# ":" && g:eskk#use_azik && g:eskk#azik_keyboard_type == 'us101'
-        return [sticky_char, "t;"]
+    elseif char ==# '+' && g:eskk#use_azik && g:eskk#azik_keyboard_type ==? 'jp106'
+      \ || char ==# ':' && g:eskk#use_azik && g:eskk#azik_keyboard_type ==? 'us101'
+        return [sticky_char, 't;']
     elseif char ==# "\<BS>"
         return ["\<C-h>"]
     else

--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1302,6 +1302,13 @@ function! s:asym_prefilter(stash) abort "{{{
         " 'X' is phase:henkan-select:delete-from-dict
         " 'L' is mode:{hira,kata,hankata}:to-zenei
         return [char]
+    elseif char ==# 'Q' && g:eskk#use_azik
+        let buf_str = a:stash.preedit.get_current_buf_str()
+        if !buf_str.rom_str.empty() && buf_str.rom_pairs.empty()
+            return [tolower(char)]
+        else
+            return [sticky_char, "nn"]
+        endif
     elseif char =~# '^[A-Z]$'
         " Treat uppercase "A" in "SAkujo" as lowercase.
         "
@@ -1317,6 +1324,9 @@ function! s:asym_prefilter(stash) abort "{{{
         else
             return [sticky_char, tolower(char)]
         endif
+    elseif char ==# "+" && g:eskk#use_azik && g:eskk#azik_keyboard_type == 'jp106'
+      \ || char ==# ":" && g:eskk#use_azik && g:eskk#azik_keyboard_type == 'us101'
+        return [sticky_char, "ta", ";"]
     elseif char ==# "\<BS>"
         return ["\<C-h>"]
     else

--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1298,12 +1298,42 @@ function! s:asym_prefilter(stash) abort "{{{
     let char = a:stash.char
     if char ==# sticky_char
         return [sticky_char]
-    elseif char ==# 'X' && !g:eskk#use_azik || char ==# 'L'
+    elseif char ==# 'X' && !g:eskk#use_azik || char ==# 'L' && !g:eskk#use_azik
         " 'X' is phase:henkan-select:delete-from-dict
         " 'L' is mode:{hira,kata,hankata}:to-zenei
         return [char]
-    elseif char ==# 'Q' && g:eskk#use_azik
-        return [sticky_char, "nn"]
+    elseif char =~# '^[ZKJDLQHWP]$' && g:eskk#use_azik "{{{
+        let buf_str = a:stash.preedit.get_current_buf_str()
+        if !buf_str.rom_str.empty() && buf_str.rom_pairs.empty()
+            if char ==# 'Z'
+                return ["a", sticky_char, "nn"]
+            elseif char ==# 'K'
+                return ["i", sticky_char, "nn"]
+            elseif char ==# 'J'
+                return ["u", sticky_char, "nn"]
+            elseif char ==# 'D'
+                return ["e", sticky_char, "nn"]
+            elseif char ==# 'L'
+                return ["o", sticky_char, "nn"]
+            elseif char ==# 'Q'
+                return ["a", sticky_char, "i"]
+            elseif char ==# 'H'
+                return ["u", sticky_char, "u"]
+            elseif char ==# 'W'
+                return ["e", sticky_char, "i"]
+            elseif char ==# 'P'
+                return ["o", sticky_char, "u"]
+            endif
+        else
+            if char ==# 'L'
+                " 'L' is mode:{hira,kata,hankata}:to-zenei
+                return [char]
+            elseif char ==# 'Q'
+                return [sticky_char, "nn"]
+            else
+                return [sticky_char, tolower(char)]
+            endif
+        endif "}}}
     elseif char =~# '^[A-Z]$'
         " Treat uppercase "A" in "SAkujo" as lowercase.
         "

--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1298,7 +1298,7 @@ function! s:asym_prefilter(stash) abort "{{{
     let char = a:stash.char
     if char ==# sticky_char
         return [sticky_char]
-    elseif char ==# 'X' || char ==# 'L'
+    elseif char ==# 'X' && !g:eskk#use_azik || char ==# 'L'
         " 'X' is phase:henkan-select:delete-from-dict
         " 'L' is mode:{hira,kata,hankata}:to-zenei
         return [char]

--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1298,7 +1298,7 @@ function! s:asym_prefilter(stash) abort "{{{
     let char = a:stash.char
     if char ==# sticky_char
         return [sticky_char]
-    elseif char ==# 'X' && !g:eskk#use_azik || char ==# 'L' && !g:eskk#use_azik
+    elseif (char ==# 'X' || char ==# 'L') && !g:eskk#use_azik
         " 'X' is phase:henkan-select:delete-from-dict
         " 'L' is mode:{hira,kata,hankata}:to-zenei
         return [char]

--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -368,7 +368,8 @@ g:eskk#cursor_color			*g:eskk#cursor_color*
 
 g:eskk#egg_like_newline				*g:eskk#egg_like_newline*
 							(デフォルト値: 0)
-	(TODO: doc)
+	もし真なら、変換候補を確定する為に<Enter>キーを押しても改行されなくなる。
+	ちなみにeggとはかな漢字変換システムWnnのクライアントプログラムのこと。
 
 g:eskk#egg_like_newline_completion	*g:eskk#egg_like_newline_completion*
 							(デフォルト値: 0)
@@ -424,11 +425,40 @@ g:eskk#convert_at_exact_match		*g:eskk#convert_at_exact_match*
 
 g:eskk#use_azik					*g:eskk#use_azik*
 							(デフォルト値: 0)
-	もし真なら、Xから始まる単語を変換出来るようになる。
-	一方、▼モードで誤った単語登録を削除することは出来なくなるため注意。
-	この変数は、自分でアルファベットテーブルを定義してAZIKで入力する場合に必要となる。
-	AZIKについては http://hp.vector.co.jp/authors/VA002116/azik/azikinfo.htm を、
-	アルファベットテーブルの登録については|eskk-alphabet-table|を参照のこと。
+	もし真なら、AZIKのアルファベットテーブルを定義して入力する場合に、
+	|vimrc|では設定できないいくつかの変換が可能となる。
+	具体的には以下のとおり。
+
+	Xから始まる単語を変換出来るようになる。~
+	例1: 社会主義 Xakqxugi
+	Note: 一方、▼モードで誤った単語登録を削除することは出来なくなる。
+
+	Z, K, J, D, L, Q, W, H, Pから始まる送り仮名を変換出来るようになる。~
+	例2: かもめが飛んだ kamomegaTLda
+	例3: さくらが咲いた sakuragaSQta
+	例4: ぱんつを編んだ pztuwoAQda
+	例5: 急いてはことを仕損ずる SWtehaktwoSislZuru
+
+	<S-;>から始まる送り仮名を変換出来るようになる。~
+	例6: くららが立った kuraragaTa<S-;>ta
+	Note: SKK辞書の仕様上、一般的なAZIKのアルファベットテーブルに加え、
+	以下の定義を追加する必要がある。
+>
+	let t = eskk#table#new('rom_to_hira*', 'rom_to_hira')
+	call t.add_map('t;', 'っ')
+	call eskk#register_mode_table('hira', t)
+<
+	AZIKについては以下のWebサイトを参照のこと。
+	http://hp.vector.co.jp/authors/VA002116/azik/azikinfo.htm
+	アルファベットテーブルについては|eskk-alphabet-table|を参照のこと。
+	また、|vimrc|の設定例は|eskk-faq-use-azik|を参照のこと。
+
+g:eskk#use_azik					*g:eskk#azik_keyboard_type*
+							(デフォルト値: "jp106")
+	AZIKを使う際のキーボード配列を指定する。
+	値は"jp106"または"us101"。
+	Note: "us101"を選択した場合、かぎかっこ"「"が入力できなくなる。
+	(TODO: "jp-pc98"を実装する?)
 
 
 
@@ -710,6 +740,9 @@ eskkの補完はpum.vimでは動作しないことに注意してください．
 					*eskk-faq-use-azik*
 Q. AZIKで入力したいです。
 A. 以下に設定例を示します。 |g:eskk#use_azik| も参照してください。
+なお、アルファベット変換テーブルは長くなりすぎるのでここでは割愛します。
+例えば以下を参照してください。
+https://github.com/hakehash/vimrc/blob/master/.vimrc#L104-L1787
 >
 	let g:eskk#use_azik=1
 	let g:eskk#azik_keyboard_type="jp106"

--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -742,7 +742,7 @@ Q. AZIKで入力したいです。
 A. 以下に設定例を示します。 |g:eskk#use_azik| も参照してください。
 なお、アルファベット変換テーブルは長くなりすぎるのでここでは割愛します。
 例えば以下を参照してください。
-https://github.com/hakehash/vimrc/blob/master/.vimrc#L104-L1787
+https://github.com/hakehash/vimrc/blob/47a31028330b8463ef73e274a733bab269735b9f/.vimrc#L108-L1791
 >
 	let g:eskk#use_azik=1
 	let g:eskk#azik_keyboard_type="jp106"

--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -692,7 +692,7 @@ A.
 	    EskkMap -type=sticky Q
 	endfunction
 
-Q. ddc.vim で eskk の補完を有効にしたいです
+Q. ddc.vim で eskk の補完を有効にしたいです。
 
 A.
 >
@@ -706,6 +706,56 @@ A.
 	    \ })
 
 eskkの補完はpum.vimでは動作しないことに注意してください．
+
+					*eskk-faq-use-azik*
+Q. AZIKで入力したいです。
+A. 以下に設定例を示します。 |g:eskk#use_azik| も参照してください。
+>
+	let g:eskk#use_azik=1
+	let g:eskk#azik_keyboard_type="jp106"
+	augroup EskkInit
+	  autocmd!
+	  autocmd User eskk-initialize-pre call s:eskk_initial_pre()
+	  autocmd User eskk-initialize-post call s:eskk_initial_post()
+	augroup END
+	function! s:eskk_initial_pre() abort
+	  let t = eskk#table#new('rom_to_hira*', 'rom_to_hira')
+	    " ここにひらがなの変換テーブルを定義する
+	  call eskk#register_mode_table('hira', t)
+	  let t = eskk#table#new('rom_to_kata*', 'rom_to_kata')
+	    " ここにカタカナの変換テーブルを定義する
+	  call eskk#register_mode_table('kata', t)
+	  let t = eskk#table#new('rom_to_hankata*', 'rom_to_hankata')
+	    " ここに半角ｶﾀｶﾅの変換テーブルを定義する
+	  call eskk#register_mode_table('hankata', t)
+	endfunction
+	function! s:eskk_initial_post() abort
+	  if g:eskk#use_azik
+	    EskkUnmap -type=mode:hira:toggle-kata q
+	    EskkUnmap -type=mode:hira:q-key q
+	    EskkUnmap -type=mode:kata:toggle-kata q
+	    EskkUnmap -type=mode:kata:q-key q
+	    EskkUnmap -type=mode:hankata:toggle-kata q
+	    EskkUnmap -type=mode:hankata:q-key q
+	    EskkUnmap -type=sticky ;
+	    EskkUnmap -type=phase:henkan-select:delete-from-dict X
+	    if g:eskk#azik_keyboard_type=="jp106"
+	      EskkMap -type=mode:hira:toggle-kata @
+	      EskkMap -type=mode:hira:q-key @
+	      EskkMap -type=mode:kata:toggle-kata @
+	      EskkMap -type=mode:kata:q-key @
+	      EskkMap -type=mode:hankata:toggle-kata @
+	      EskkMap -type=mode:hankata:q-key @
+	    elseif g:eskk#azik_keyboard_type=="us101"
+	      EskkMap -type=mode:hira:toggle-kata [
+	      EskkMap -type=mode:hira:q-key [
+	      EskkMap -type=mode:kata:toggle-kata [
+	      EskkMap -type=mode:kata:q-key [
+	      EskkMap -type=mode:hankata:toggle-kata [
+	      EskkMap -type=mode:hankata:q-key [
+	    endif
+	  endif
+	endfunction
 }}}
 ==============================================================================
 TODO						*eskk-todo* {{{

--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -678,8 +678,8 @@ Q. Sticky キーを無効化または変更したいです。
 
 A.
 >
-	autocmd User eskk-initialize-post call s:eskk_initial_pre()
-	function! s:eskk_initial_pre() abort
+	autocmd User eskk-initialize-post call s:eskk_initial_post()
+	function! s:eskk_initial_post() abort
 	    EskkUnmap -type=sticky ;
 	    EskkMap -type=sticky Q
 	endfunction

--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -422,6 +422,14 @@ g:eskk#convert_at_exact_match		*g:eskk#convert_at_exact_match*
 							(デフォルト値: 0)
 	(TODO: doc)
 
+g:eskk#use_azik					*g:eskk#use_azik*
+							(デフォルト値: 0)
+	もし真なら、Xから始まる単語を変換出来るようになる。
+	一方、▼モードで誤った単語登録を削除することは出来なくなるため注意。
+	この変数は、自分でアルファベットテーブルを定義してAZIKで入力する場合に必要となる。
+	AZIKについては http://hp.vector.co.jp/authors/VA002116/azik/azikinfo.htm を、
+	アルファベットテーブルの登録については|eskk-alphabet-table|を参照のこと。
+
 
 
 デバッグ用変数

--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -744,8 +744,8 @@ A. 以下に設定例を示します。 |g:eskk#use_azik| も参照してくだ�
 例えば以下を参照してください。
 https://github.com/hakehash/vimrc/blob/47a31028330b8463ef73e274a733bab269735b9f/.vimrc#L108-L1791
 >
-	let g:eskk#use_azik=1
-	let g:eskk#azik_keyboard_type="jp106"
+	let g:eskk#use_azik = 1
+	let g:eskk#azik_keyboard_type = 'jp106'
 	augroup EskkInit
 	  autocmd!
 	  autocmd User eskk-initialize-pre call s:eskk_initial_pre()

--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -733,10 +733,13 @@ A. 以下に設定例を示します。 |g:eskk#use_azik| も参照してくだ�
 	  if g:eskk#use_azik
 	    EskkUnmap -type=mode:hira:toggle-kata q
 	    EskkUnmap -type=mode:hira:q-key q
+	    EskkUnmap -type=mode:hira:l-key l
 	    EskkUnmap -type=mode:kata:toggle-kata q
 	    EskkUnmap -type=mode:kata:q-key q
+	    EskkUnmap -type=mode:kata:l-key l
 	    EskkUnmap -type=mode:hankata:toggle-kata q
 	    EskkUnmap -type=mode:hankata:q-key q
+	    EskkUnmap -type=mode:hankata:l-key l
 	    EskkUnmap -type=sticky ;
 	    EskkUnmap -type=phase:henkan-select:delete-from-dict X
 	    if g:eskk#azik_keyboard_type=="jp106"

--- a/plugin/eskk.vim
+++ b/plugin/eskk.vim
@@ -36,9 +36,6 @@ endif
 if !exists('g:eskk#dont_map_default_if_already_mapped')
   let g:eskk#dont_map_default_if_already_mapped = 1
 endif
-if !exists('g:eskk#use_azik')
-  let g:eskk#use_azik = 0
-endif
 
 
 if !g:eskk#no_default_mappings

--- a/plugin/eskk.vim
+++ b/plugin/eskk.vim
@@ -36,6 +36,9 @@ endif
 if !exists('g:eskk#dont_map_default_if_already_mapped')
   let g:eskk#dont_map_default_if_already_mapped = 1
 endif
+if !exists('g:eskk#use_azik')
+  let g:eskk#use_azik = 0
+endif
 
 
 if !g:eskk#no_default_mappings


### PR DESCRIPTION
eskk.vimでAZIKを使いたい場合、.vimrcにてアルファベット変換テーブルを定義すれば入力は出来るようになるのですが、変換についてはそれだけだと対応し切れない部分があるため、autoload/eskk.vimにPreprocessorを追加しました。
内容はdoc/eskk.jaxに記載しています(ついでにヘルプファイルの他の箇所にも若干追記・修正しています)。
AZIK用のアルファベット変換テーブルについては長くなりすぎる(1700行弱)ため、ヘルプファイルでは例示せずひとまず私の.vimrcを参照してもらうようにしています。
